### PR TITLE
Fix HEAP size for USB_Device/MSC_Standalone demo for STM32H743I-EVAL

### DIFF
--- a/Projects/STM32H743I-EVAL/Applications/USB_Device/MSC_Standalone/MDK-ARM/startup_stm32h743xx.s
+++ b/Projects/STM32H743I-EVAL/Applications/USB_Device/MSC_Standalone/MDK-ARM/startup_stm32h743xx.s
@@ -41,7 +41,7 @@ __initial_sp
 ;   <o>  Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
 ; </h>
 
-Heap_Size      EQU     0x2000
+Heap_Size      EQU     0x4000
 
                 AREA    HEAP, NOINIT, READWRITE, ALIGN=3
 __heap_base

--- a/Projects/STM32H743I-EVAL/Applications/USB_Device/MSC_Standalone/SW4STM32/STM32H743I-EVAL_USBD-FS/STM32H743XIHx_FLASH.ld
+++ b/Projects/STM32H743I-EVAL/Applications/USB_Device/MSC_Standalone/SW4STM32/STM32H743I-EVAL_USBD-FS/STM32H743XIHx_FLASH.ld
@@ -38,7 +38,7 @@ ENTRY(Reset_Handler)
 /* Highest address of the user mode stack */
 _estack = 0x24080000;    /* end of RAM */
 /* Generate a link error if heap and stack don't fit into RAM */
-_Min_Heap_Size = 0x2000;      /* required amount of heap  */
+_Min_Heap_Size = 0x4000;      /* required amount of heap  */
 _Min_Stack_Size = 0x2000; /* required amount of stack */
 
 /* Specify the memory areas */

--- a/Projects/STM32H743I-EVAL/Applications/USB_Device/MSC_Standalone/SW4STM32/STM32H743I-EVAL_USBD-HS/STM32H743XIHx_FLASH.ld
+++ b/Projects/STM32H743I-EVAL/Applications/USB_Device/MSC_Standalone/SW4STM32/STM32H743I-EVAL_USBD-HS/STM32H743XIHx_FLASH.ld
@@ -38,7 +38,7 @@ ENTRY(Reset_Handler)
 /* Highest address of the user mode stack */
 _estack = 0x24080000;    /* end of RAM */
 /* Generate a link error if heap and stack don't fit into RAM */
-_Min_Heap_Size = 0x2000;      /* required amount of heap  */
+_Min_Heap_Size = 0x4000;      /* required amount of heap  */
 _Min_Stack_Size = 0x2000; /* required amount of stack */
 
 /* Specify the memory areas */


### PR DESCRIPTION
HEAP size for EWARM was correct 0x4000.
Fixed HEAP size for MDK-ARM and SW4STM32.

## IMPORTANT INFORMATION 

### Contributor License Agreement (CLA)
* The Pull Request feature will be considered by STMicroelectronics only after a **Contributor License Agreement (CLA)** mechanism has been deployed.
* We are currently working on the set-up of this procedure. 
  


