### PR TITLE
Fix  RAM for Algorithm  start address for JPEG/JPEG_DecodingFromFLASH_DMA  demo  for STM32H747I-DISCO

### DIFF
--- a/Projects/STM32H747I-DISCO/Examples/JPEG/JPEG_DecodingFromFLASH_DMA/MDK-ARM/Project.uvoptx
+++ b/Projects/STM32H747I-DISCO/Examples/JPEG/JPEG_DecodingFromFLASH_DMA/MDK-ARM/Project.uvoptx
@@ -344,6 +344,13 @@
       <pszMrulep></pszMrulep>
       <pSingCmdsp></pSingCmdsp>
       <pMultCmdsp></pMultCmdsp>
+      <DebugDescription>
+      <Enable>1</Enable>
+      <EnableFlashSeq>1</EnableFlashSeq>
+      <EnableLog>0</EnableLog>
+      <Protocol>2</Protocol>
+      <DbgClock>10000000</DbgClock>
+      </DebugDescription>
     </TargetOption>
   </Target>
 


### PR DESCRIPTION
RAM for Algorithm  start address was incorrect 0x20000000  in CM4 core MDK-ARM Project.
Fixed  RAM for Algorithm  start address for MDK-ARM

## IMPORTANT INFORMATION 

### Contributor License Agreement (CLA)
* The Pull Request feature will be considered by STMicroelectronics only after a **Contributor License Agreement (CLA)** mechanism has been deployed.
* We are currently working on the set-up of this procedure. 
  


