### PR TITLE
incorrect spelling of SWIPECONTAINERWITHCALLBACK_HPP

### DIFF
--- a/Projects/STM32H7B3I-DK/Demonstrations/ClockAndWeather/TouchGFX/widgets/SwipeContainerWithCallback.hpp
+++ b/Projects/STM32H7B3I-DK/Demonstrations/ClockAndWeather/TouchGFX/widgets/SwipeContainerWithCallback.hpp
@@ -13,7 +13,7 @@
   ******************************************************************************
   */
 
-#ifndef SWIPECONTAINERWITHCALLBACK_HHP
+#ifndef SWIPECONTAINERWITHCALLBACK_HPP
 #define SWIPECONTAINERWITHCALLBACK_HPP
 
 #include <touchgfx/containers/ListLayout.hpp>


### PR DESCRIPTION
I have finished the signature of a **Contributor License Agreement (CLA)**.

**Description**
The word spelling is incorrect of the macro definitions for the header file.
- SWIPECONTAINERWITHCALLBACK_HHP
    - https://github.com/STMicroelectronics/STM32CubeH7/blob/beced99ac090fece04d1e0eb6648b8075e156c6c/Projects/STM32H7B3I-DK/Demonstrations/ClockAndWeather/TouchGFX/widgets/SwipeContainerWithCallback.hpp#L16

- SWIPECONTAINERWITHCALLBACK_HPP
    - https://github.com/STMicroelectronics/STM32CubeH7/blob/beced99ac090fece04d1e0eb6648b8075e156c6c/Projects/STM32H7B3I-DK/Demonstrations/ClockAndWeather/TouchGFX/widgets/SwipeContainerWithCallback.hpp#L17

**Describe the set-up**
 * STM32H7B3I-DK
 * STM32CubeIDE 1.4.0
