### PR TITLE
Make FatFS working in DMA mode on H7 with cache enabled

### DIFF
--- a/Middlewares/Third_Party/FatFs/src/ff.h
+++ b/Middlewares/Third_Party/FatFs/src/ff.h
@@ -122,7 +122,7 @@ typedef struct {
 	DWORD	dirbase;		/* Root directory base sector/cluster */
 	DWORD	database;		/* Data base sector */
 	DWORD	winsect;		/* Current sector appearing in the win[] */
-	BYTE	win[_MAX_SS];	/* Disk access window for Directory, FAT (and file data at tiny cfg) */
+	BYTE	win[_MAX_SS] __attribute__((aligned(32)));	/* Disk access window for Directory, FAT (and file data at tiny cfg) */
 } FATFS;
 
 
@@ -167,7 +167,7 @@ typedef struct {
 	DWORD*	cltbl;			/* Pointer to the cluster link map table (nulled on open, set by application) */
 #endif
 #if !_FS_TINY
-	BYTE	buf[_MAX_SS];	/* File private data read/write window */
+	BYTE	buf[_MAX_SS] __attribute__((aligned(32)));	/* File private data read/write window */
 #endif
 } FIL;
 


### PR DESCRIPTION
Without this, FatFS just doesn't work. (What is strange, even _MAX_SS is dividable by 32)
