### PR TITLE
Fix address calculation in BSP_LCD_FillRGBRect

### DIFF
--- a/Drivers/BSP/STM32H735G-DK/stm32h735g_discovery_lcd.c
+++ b/Drivers/BSP/STM32H735G-DK/stm32h735g_discovery_lcd.c
@@ -1046,7 +1046,7 @@ int32_t BSP_LCD_FillRGBRect(uint32_t Instance, uint32_t Xpos, uint32_t Ypos, uin
   for(i = 0; i < Height; i++)
   {
     /* Get the line address */
-    Xaddress = hlcd_ltdc.LayerCfg[Lcd_Ctx[Instance].ActiveLayer].FBStartAdress + (PixelFormatFactor*(((Lcd_Ctx[Instance].XSize + i)*Ypos) + Xpos));
+    Xaddress = hlcd_ltdc.LayerCfg[Lcd_Ctx[Instance].ActiveLayer].FBStartAdress + (PixelFormatFactor*((Lcd_Ctx[Instance].XSize*(Ypos + i)) + Xpos));
 
     /* Write line */
     if(Lcd_Ctx[Instance].PixelFormat == LCD_PIXEL_FORMAT_RGB565)

--- a/Drivers/BSP/STM32H743I-EVAL/stm32h743i_eval_lcd.c
+++ b/Drivers/BSP/STM32H743I-EVAL/stm32h743i_eval_lcd.c
@@ -1143,7 +1143,7 @@ int32_t BSP_LCD_FillRGBRect(uint32_t Instance, uint32_t Xpos, uint32_t Ypos, uin
   for(i = 0; i < Height; i++)
   {
     /* Get the line address */
-    Xaddress = hlcd_ltdc.LayerCfg[Lcd_Ctx[Instance].ActiveLayer].FBStartAdress + (PixelFormatFactor*(((Lcd_Ctx[Instance].XSize + i)*Ypos) + Xpos));
+    Xaddress = hlcd_ltdc.LayerCfg[Lcd_Ctx[Instance].ActiveLayer].FBStartAdress + (PixelFormatFactor*((Lcd_Ctx[Instance].XSize*(Ypos + i)) + Xpos));
 
     /* Write line */
     if(Lcd_Ctx[Instance].PixelFormat == LCD_PIXEL_FORMAT_RGB565)

--- a/Drivers/BSP/STM32H745I-DISCO/stm32h745i_discovery_lcd.c
+++ b/Drivers/BSP/STM32H745I-DISCO/stm32h745i_discovery_lcd.c
@@ -1069,7 +1069,7 @@ int32_t BSP_LCD_FillRGBRect(uint32_t Instance, uint32_t Xpos, uint32_t Ypos, uin
   for(i = 0; i < Height; i++)
   {
     /* Get the line address */
-    Xaddress = hlcd_ltdc.LayerCfg[Lcd_Ctx[Instance].ActiveLayer].FBStartAdress + (Lcd_Ctx[Instance].BppFactor*(((Lcd_Ctx[Instance].XSize + i)*Ypos) + Xpos));
+    Xaddress = hlcd_ltdc.LayerCfg[Lcd_Ctx[Instance].ActiveLayer].FBStartAdress + (Lcd_Ctx[Instance].BppFactor*((Lcd_Ctx[Instance].XSize*(Ypos + i)) + Xpos));
 
     /* Write line */
     if(Lcd_Ctx[Instance].PixelFormat == LCD_PIXEL_FORMAT_RGB565)

--- a/Drivers/BSP/STM32H747I-DISCO/stm32h747i_discovery_lcd.c
+++ b/Drivers/BSP/STM32H747I-DISCO/stm32h747i_discovery_lcd.c
@@ -1524,7 +1524,7 @@ int32_t BSP_LCD_FillRGBRect(uint32_t Instance, uint32_t Xpos, uint32_t Ypos, uin
   for(i = 0; i < Height; i++)
   {
     /* Get the line address */
-    Xaddress = hlcd_ltdc.LayerCfg[Lcd_Ctx[Instance].ActiveLayer].FBStartAdress + (Lcd_Ctx[Instance].BppFactor*(((Lcd_Ctx[Instance].XSize + i)*Ypos) + Xpos));
+    Xaddress = hlcd_ltdc.LayerCfg[Lcd_Ctx[Instance].ActiveLayer].FBStartAdress + (Lcd_Ctx[Instance].BppFactor*((Lcd_Ctx[Instance].XSize*(Ypos + i)) + Xpos));
 
     /* Write line */
     if(Lcd_Ctx[Instance].PixelFormat == LCD_PIXEL_FORMAT_RGB565)

--- a/Drivers/BSP/STM32H747I-EVAL/stm32h747i_eval_lcd.c
+++ b/Drivers/BSP/STM32H747I-EVAL/stm32h747i_eval_lcd.c
@@ -1465,7 +1465,7 @@ int32_t BSP_LCD_FillRGBRect(uint32_t Instance, uint32_t Xpos, uint32_t Ypos, uin
   for(i = 0; i < Height; i++)
   {
     /* Get the line address */
-    Xaddress = hlcd_ltdc.LayerCfg[Lcd_Ctx[Instance].ActiveLayer].FBStartAdress + (Lcd_Ctx[Instance].BppFactor*(((Lcd_Ctx[Instance].XSize + i)*Ypos) + Xpos));
+    Xaddress = hlcd_ltdc.LayerCfg[Lcd_Ctx[Instance].ActiveLayer].FBStartAdress + (Lcd_Ctx[Instance].BppFactor*((Lcd_Ctx[Instance].XSize*(Ypos + i)) + Xpos));
 
     /* Write line */
     if(Lcd_Ctx[Instance].PixelFormat == LCD_PIXEL_FORMAT_RGB565)

--- a/Drivers/BSP/STM32H750B-DK/stm32h750b_discovery_lcd.c
+++ b/Drivers/BSP/STM32H750B-DK/stm32h750b_discovery_lcd.c
@@ -1069,7 +1069,7 @@ int32_t BSP_LCD_FillRGBRect(uint32_t Instance, uint32_t Xpos, uint32_t Ypos, uin
   for(i = 0; i < Height; i++)
   {
     /* Get the line address */
-    Xaddress = hlcd_ltdc.LayerCfg[Lcd_Ctx[Instance].ActiveLayer].FBStartAdress + (Lcd_Ctx[Instance].BppFactor*(((Lcd_Ctx[Instance].XSize + i)*Ypos) + Xpos));
+    Xaddress = hlcd_ltdc.LayerCfg[Lcd_Ctx[Instance].ActiveLayer].FBStartAdress + (Lcd_Ctx[Instance].BppFactor*((Lcd_Ctx[Instance].XSize*(Ypos + i)) + Xpos));
 
     /* Write line */
     if(Lcd_Ctx[Instance].PixelFormat == LCD_PIXEL_FORMAT_RGB565)

--- a/Drivers/BSP/STM32H7B3I-DK/stm32h7b3i_discovery_lcd.c
+++ b/Drivers/BSP/STM32H7B3I-DK/stm32h7b3i_discovery_lcd.c
@@ -1066,7 +1066,7 @@ int32_t BSP_LCD_FillRGBRect(uint32_t Instance, uint32_t Xpos, uint32_t Ypos, uin
   for(i = 0; i < Height; i++)
   {
     /* Get the line address */
-    Xaddress = hlcd_ltdc.LayerCfg[Lcd_Ctx[Instance].ActiveLayer].FBStartAdress + (Lcd_Ctx[Instance].BppFactor*(((Lcd_Ctx[Instance].XSize + i)*Ypos) + Xpos));
+    Xaddress = hlcd_ltdc.LayerCfg[Lcd_Ctx[Instance].ActiveLayer].FBStartAdress + (Lcd_Ctx[Instance].BppFactor*((Lcd_Ctx[Instance].XSize*(Ypos + i)) + Xpos));
 
     /* Write line */
     if(Lcd_Ctx[Instance].PixelFormat == LCD_PIXEL_FORMAT_RGB565)

--- a/Drivers/BSP/STM32H7B3I-EVAL/stm32h7b3i_eval_lcd.c
+++ b/Drivers/BSP/STM32H7B3I-EVAL/stm32h7b3i_eval_lcd.c
@@ -1087,7 +1087,7 @@ int32_t BSP_LCD_FillRGBRect(uint32_t Instance, uint32_t Xpos, uint32_t Ypos, uin
   for(i = 0; i < Height; i++)
   {
     /* Get the line address */
-    Xaddress = hlcd_ltdc.LayerCfg[Lcd_Ctx[Instance].ActiveLayer].FBStartAdress + (Lcd_Ctx[Instance].BppFactor*(((Lcd_Ctx[Instance].XSize + i)*Ypos) + Xpos));
+    Xaddress = hlcd_ltdc.LayerCfg[Lcd_Ctx[Instance].ActiveLayer].FBStartAdress + (Lcd_Ctx[Instance].BppFactor*((Lcd_Ctx[Instance].XSize*(Ypos + i)) + Xpos));
 
     /* Write line */
     if(Lcd_Ctx[Instance].PixelFormat == LCD_PIXEL_FORMAT_RGB565)


### PR DESCRIPTION
This fixes an address calculation in `stm32h7b3i_discovery_lcd.c`