### PR TITLE
Fix IRQHandler in stm32h7b3i_discovery_camera.h

### DIFF
--- a/Drivers/BSP/STM32H7B3I-DK/stm32h7b3i_discovery_camera.h
+++ b/Drivers/BSP/STM32H7B3I-DK/stm32h7b3i_discovery_camera.h
@@ -162,8 +162,8 @@ typedef struct
 #define CAMERA_NIGHT_MODE_SET           0x00U   /* Disable night mode         */
 #define CAMERA_NIGHT_MODE_RESET         0x01U   /* Enable night mode          */
 
-#define CAMERA_IRQHandler               DCMI_IRQHandler
-#define CAMERA_DMA_IRQHandler           DMA2_Stream1_IRQHandler
+#define BSP_CAMERA_IRQHandler               DCMI_IRQHandler
+#define BSP_CAMERA_DMA_IRQHandler           DMA2_Stream1_IRQHandler
 
 
 #define CAMERA_OV9655_ADDRESS           0x60U


### PR DESCRIPTION
The function `BSP_CAMERA_IRQHandler` was meant to be used as an interrupt handler, but because of this typo in the header file, they were never actually used and the board would crash when using a camera.