### PR TITLE
Add cache maintenance operation in BSP_LCD_FillRGBRect() for BSP boards

### DIFF
--- a/Drivers/BSP/STM32H735G-DK/stm32h735g_discovery_lcd.c
+++ b/Drivers/BSP/STM32H735G-DK/stm32h735g_discovery_lcd.c
@@ -1048,6 +1048,10 @@ int32_t BSP_LCD_FillRGBRect(uint32_t Instance, uint32_t Xpos, uint32_t Ypos, uin
     /* Get the line address */
     Xaddress = hlcd_ltdc.LayerCfg[Lcd_Ctx[Instance].ActiveLayer].FBStartAdress + (PixelFormatFactor*((Lcd_Ctx[Instance].XSize*(Ypos + i)) + Xpos));
 
+#if (USE_BSP_CPU_CACHE_MAINTENANCE == 1)
+    SCB_CleanDCache_by_Addr((uint32_t *)pdata, PixelFormatFactor*Lcd_Ctx[Instance].XSize);
+#endif /* USE_BSP_CPU_CACHE_MAINTENANCE */
+
     /* Write line */
     if(Lcd_Ctx[Instance].PixelFormat == LCD_PIXEL_FORMAT_RGB565)
     {

--- a/Drivers/BSP/STM32H743I-EVAL/stm32h743i_eval_lcd.c
+++ b/Drivers/BSP/STM32H743I-EVAL/stm32h743i_eval_lcd.c
@@ -1145,6 +1145,10 @@ int32_t BSP_LCD_FillRGBRect(uint32_t Instance, uint32_t Xpos, uint32_t Ypos, uin
     /* Get the line address */
     Xaddress = hlcd_ltdc.LayerCfg[Lcd_Ctx[Instance].ActiveLayer].FBStartAdress + (PixelFormatFactor*((Lcd_Ctx[Instance].XSize*(Ypos + i)) + Xpos));
 
+#if (USE_BSP_CPU_CACHE_MAINTENANCE == 1)
+    SCB_CleanDCache_by_Addr((uint32_t *)pdata, PixelFormatFactor*Lcd_Ctx[Instance].XSize);
+#endif /* USE_BSP_CPU_CACHE_MAINTENANCE */
+
     /* Write line */
     if(Lcd_Ctx[Instance].PixelFormat == LCD_PIXEL_FORMAT_RGB565)
     {

--- a/Drivers/BSP/STM32H745I-DISCO/stm32h745i_discovery_lcd.c
+++ b/Drivers/BSP/STM32H745I-DISCO/stm32h745i_discovery_lcd.c
@@ -1071,6 +1071,10 @@ int32_t BSP_LCD_FillRGBRect(uint32_t Instance, uint32_t Xpos, uint32_t Ypos, uin
     /* Get the line address */
     Xaddress = hlcd_ltdc.LayerCfg[Lcd_Ctx[Instance].ActiveLayer].FBStartAdress + (Lcd_Ctx[Instance].BppFactor*((Lcd_Ctx[Instance].XSize*(Ypos + i)) + Xpos));
 
+#if (USE_BSP_CPU_CACHE_MAINTENANCE == 1)
+    SCB_CleanDCache_by_Addr((uint32_t *)pdata, Lcd_Ctx[Instance].BppFactor*Lcd_Ctx[Instance].XSize);
+#endif /* USE_BSP_CPU_CACHE_MAINTENANCE */
+
     /* Write line */
     if(Lcd_Ctx[Instance].PixelFormat == LCD_PIXEL_FORMAT_RGB565)
     {

--- a/Drivers/BSP/STM32H747I-DISCO/stm32h747i_discovery_lcd.c
+++ b/Drivers/BSP/STM32H747I-DISCO/stm32h747i_discovery_lcd.c
@@ -1526,6 +1526,10 @@ int32_t BSP_LCD_FillRGBRect(uint32_t Instance, uint32_t Xpos, uint32_t Ypos, uin
     /* Get the line address */
     Xaddress = hlcd_ltdc.LayerCfg[Lcd_Ctx[Instance].ActiveLayer].FBStartAdress + (Lcd_Ctx[Instance].BppFactor*((Lcd_Ctx[Instance].XSize*(Ypos + i)) + Xpos));
 
+#if (USE_BSP_CPU_CACHE_MAINTENANCE == 1)
+    SCB_CleanDCache_by_Addr((uint32_t *)pdata, Lcd_Ctx[Instance].BppFactor*Lcd_Ctx[Instance].XSize);
+#endif /* USE_BSP_CPU_CACHE_MAINTENANCE */
+
     /* Write line */
     if(Lcd_Ctx[Instance].PixelFormat == LCD_PIXEL_FORMAT_RGB565)
     {

--- a/Drivers/BSP/STM32H747I-EVAL/stm32h747i_eval_lcd.c
+++ b/Drivers/BSP/STM32H747I-EVAL/stm32h747i_eval_lcd.c
@@ -1467,6 +1467,10 @@ int32_t BSP_LCD_FillRGBRect(uint32_t Instance, uint32_t Xpos, uint32_t Ypos, uin
     /* Get the line address */
     Xaddress = hlcd_ltdc.LayerCfg[Lcd_Ctx[Instance].ActiveLayer].FBStartAdress + (Lcd_Ctx[Instance].BppFactor*((Lcd_Ctx[Instance].XSize*(Ypos + i)) + Xpos));
 
+#if (USE_BSP_CPU_CACHE_MAINTENANCE == 1)
+    SCB_CleanDCache_by_Addr((uint32_t *)pdata, Lcd_Ctx[Instance].BppFactor*Lcd_Ctx[Instance].XSize);
+#endif /* USE_BSP_CPU_CACHE_MAINTENANCE */
+
     /* Write line */
     if(Lcd_Ctx[Instance].PixelFormat == LCD_PIXEL_FORMAT_RGB565)
     {

--- a/Drivers/BSP/STM32H750B-DK/stm32h750b_discovery_lcd.c
+++ b/Drivers/BSP/STM32H750B-DK/stm32h750b_discovery_lcd.c
@@ -1071,6 +1071,10 @@ int32_t BSP_LCD_FillRGBRect(uint32_t Instance, uint32_t Xpos, uint32_t Ypos, uin
     /* Get the line address */
     Xaddress = hlcd_ltdc.LayerCfg[Lcd_Ctx[Instance].ActiveLayer].FBStartAdress + (Lcd_Ctx[Instance].BppFactor*((Lcd_Ctx[Instance].XSize*(Ypos + i)) + Xpos));
 
+#if (USE_BSP_CPU_CACHE_MAINTENANCE == 1)
+    SCB_CleanDCache_by_Addr((uint32_t *)pdata, Lcd_Ctx[Instance].BppFactor*Lcd_Ctx[Instance].XSize);
+#endif /* USE_BSP_CPU_CACHE_MAINTENANCE */
+
     /* Write line */
     if(Lcd_Ctx[Instance].PixelFormat == LCD_PIXEL_FORMAT_RGB565)
     {

--- a/Drivers/BSP/STM32H7B3I-DK/stm32h7b3i_discovery_lcd.c
+++ b/Drivers/BSP/STM32H7B3I-DK/stm32h7b3i_discovery_lcd.c
@@ -1068,6 +1068,10 @@ int32_t BSP_LCD_FillRGBRect(uint32_t Instance, uint32_t Xpos, uint32_t Ypos, uin
     /* Get the line address */
     Xaddress = hlcd_ltdc.LayerCfg[Lcd_Ctx[Instance].ActiveLayer].FBStartAdress + (Lcd_Ctx[Instance].BppFactor*((Lcd_Ctx[Instance].XSize*(Ypos + i)) + Xpos));
 
+#if (USE_BSP_CPU_CACHE_MAINTENANCE == 1)
+    SCB_CleanDCache_by_Addr((uint32_t *)pdata, Lcd_Ctx[Instance].BppFactor*Lcd_Ctx[Instance].XSize);
+#endif /* USE_BSP_CPU_CACHE_MAINTENANCE */
+
     /* Write line */
     if(Lcd_Ctx[Instance].PixelFormat == LCD_PIXEL_FORMAT_RGB565)
     {

--- a/Drivers/BSP/STM32H7B3I-EVAL/stm32h7b3i_eval_lcd.c
+++ b/Drivers/BSP/STM32H7B3I-EVAL/stm32h7b3i_eval_lcd.c
@@ -1089,6 +1089,10 @@ int32_t BSP_LCD_FillRGBRect(uint32_t Instance, uint32_t Xpos, uint32_t Ypos, uin
     /* Get the line address */
     Xaddress = hlcd_ltdc.LayerCfg[Lcd_Ctx[Instance].ActiveLayer].FBStartAdress + (Lcd_Ctx[Instance].BppFactor*((Lcd_Ctx[Instance].XSize*(Ypos + i)) + Xpos));
 
+#if (USE_BSP_CPU_CACHE_MAINTENANCE == 1)
+    SCB_CleanDCache_by_Addr((uint32_t *)pdata, Lcd_Ctx[Instance].BppFactor*Lcd_Ctx[Instance].XSize);
+#endif /* USE_BSP_CPU_CACHE_MAINTENANCE */
+
     /* Write line */
     if(Lcd_Ctx[Instance].PixelFormat == LCD_PIXEL_FORMAT_RGB565)
     {


### PR DESCRIPTION
Hi,

A display issue is detected when USE_DMA2D_TO_FILL_RGB_RECT is activated.

This display issue is related to the cache that must be maintained in BSP_LCD_FillRGBRect() for the H7 BSP drivers of the following board:

• H7B3I_EVAL
• H735G_DK
• H743I_EVAL
• H745I_EVAL
• H747I_DK
• H747I_EVAL
• H750B_DK

With regards,