### PR TITLE
Fix __HAL_RCC_CSI_CALIBRATIONVALUE_ADJUST macro

### DIFF
--- a/Drivers/STM32H7xx_HAL_Driver/Inc/stm32h7xx_hal_rcc.h
+++ b/Drivers/STM32H7xx_HAL_Driver/Inc/stm32h7xx_hal_rcc.h
@@ -7249,11 +7249,11 @@ typedef struct
              {                                                                                                                           \
                 if((__CSICalibrationValue__) == RCC_CSICALIBRATION_DEFAULT)                                                              \
                 {                                                                                                                        \
-                  MODIFY_REG(RCC->HSICFGR, HAL_RCC_REV_Y_CSITRIM_Msk, ((uint32_t)0x10) << HAL_RCC_REV_Y_CSITRIM_Pos);                    \
+                  MODIFY_REG(RCC->CSICFGR, HAL_RCC_REV_Y_CSITRIM_Msk, ((uint32_t)0x10) << HAL_RCC_REV_Y_CSITRIM_Pos);                    \
                 }                                                                                                                        \
                 else                                                                                                                     \
                 {                                                                                                                        \
-                  MODIFY_REG(RCC->HSICFGR, HAL_RCC_REV_Y_CSITRIM_Msk, (uint32_t)(__CSICalibrationValue__) << HAL_RCC_REV_Y_CSITRIM_Pos); \
+                  MODIFY_REG(RCC->CSICFGR, HAL_RCC_REV_Y_CSITRIM_Msk, (uint32_t)(__CSICalibrationValue__) << HAL_RCC_REV_Y_CSITRIM_Pos); \
                 }                                                                                                                        \
              }                                                                                                                           \
              else                                                                                                                        \


### PR DESCRIPTION
As you can see for `HAL_GetREVID() <= REV_ID_Y` the wrong register is used. It uses `RCC->HSICFGR` instead of `RCC->CSICFGR`, so **H**SI is configured instead of **C**SI but with the CSI value.
This leads in a wrong calibration when microcontroller has a revision id lower or equal `REV_ID_Y`.


#### Contributor License Agreement (CLA)
* I signed a **Contributor License Agreement (CLA)**.
