### PR TITLE
Eth: Clear Rx and Tx pending bit before processing

### DIFF
--- a/Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_eth.c
+++ b/Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_eth.c
@@ -1479,6 +1479,8 @@ void HAL_ETH_IRQHandler(ETH_HandleTypeDef *heth)
   {
     if(__HAL_ETH_DMA_GET_IT_SOURCE(heth, ETH_DMACIER_RIE))
     {
+      /* Clear the Eth DMA Rx IT pending bits */
+      __HAL_ETH_DMA_CLEAR_IT(heth, ETH_DMACSR_RI | ETH_DMACSR_NIS);
 
 #if (USE_HAL_ETH_REGISTER_CALLBACKS == 1)
       /*Call registered Receive complete callback*/
@@ -1487,9 +1489,6 @@ void HAL_ETH_IRQHandler(ETH_HandleTypeDef *heth)
       /* Receive complete callback */
       HAL_ETH_RxCpltCallback(heth);
 #endif  /* USE_HAL_ETH_REGISTER_CALLBACKS */
-
-      /* Clear the Eth DMA Rx IT pending bits */
-      __HAL_ETH_DMA_CLEAR_IT(heth, ETH_DMACSR_RI | ETH_DMACSR_NIS);
     }
   }
 
@@ -1498,6 +1497,9 @@ void HAL_ETH_IRQHandler(ETH_HandleTypeDef *heth)
   {
     if(__HAL_ETH_DMA_GET_IT_SOURCE(heth, ETH_DMACIER_TIE))
     {
+      /* Clear the Eth DMA Tx IT pending bits */
+      __HAL_ETH_DMA_CLEAR_IT(heth, ETH_DMACSR_TI | ETH_DMACSR_NIS);
+
 #if (USE_HAL_ETH_REGISTER_CALLBACKS == 1)
         /*Call registered Transmit complete callback*/
         heth->TxCpltCallback(heth);
@@ -1505,9 +1507,6 @@ void HAL_ETH_IRQHandler(ETH_HandleTypeDef *heth)
       /* Transfer complete callback */
       HAL_ETH_TxCpltCallback(heth);
 #endif  /* USE_HAL_ETH_REGISTER_CALLBACKS */
-
-      /* Clear the Eth DMA Tx IT pending bits */
-      __HAL_ETH_DMA_CLEAR_IT(heth, ETH_DMACSR_TI | ETH_DMACSR_NIS);
     }
   }
 


### PR DESCRIPTION
If Rx bit is clear after processing this situation could happen:
- Packet 1 received
- RI bit 0->1 -> interrupt invoked
- Start processing the packet 1
- End processing the packet 1
- Packet 2 received
- Clear RI bit 1->0
- End of interrupt routine
- No interrupt invoked for packet 2
- Packet 3 received
- RI bit 0->1 -> interrupt invoked
- Start processing the packet 2
- End processing the packet 2
- Start processing the packet 3
- End processing the packet 3

Result:
- Packet 2 is not processed upon receive

When the Rx/Tx pending bit is clear before processing this situation could happen:
- Packet 1 received
- RI bit 0->1 -> interrupt invoked
- Clear RI bit 1->0
- Packet 2 received
- Start processing the packet 1
- End processing the packet 1
- Start processing the packet 2
- End processing the packet 2
- End of interrupt routine
- RI bit active -> interrupt invoked
- No Rx packet in the queue
- End of interrupt routine

Result:
- Rx interrupt routine invoked - no data in the queue -> OK

## IMPORTANT INFORMATION

### Contributor License Agreement (CLA)
* The Pull Request feature will be considered by STMicroelectronics after the signature of a **Contributor License Agreement (CLA)** by the submitter.
* If you did not sign such agreement, please follow the steps mentioned in the CONTRIBUTING.md file.
