### PR TITLE
stm32H7 spi LL driver read address of the Tx/Rx reg. for DMA

### DIFF
--- a/Drivers/STM32H7xx_HAL_Driver/Inc/stm32h7xx_ll_spi.h
+++ b/Drivers/STM32H7xx_HAL_Driver/Inc/stm32h7xx_ll_spi.h
@@ -2414,6 +2414,28 @@ __STATIC_INLINE uint32_t LL_SPI_IsEnabledDMAReq_TX(SPI_TypeDef *SPIx)
 }
 
 /**
+  * @brief  Get the data register address used for DMA transfer
+  * @rmtoll TXDR           TXDR            LL_SPI_DMA_GetTxRegAddr
+  * @param  SPIx SPI Instance
+  * @retval Address of data register
+  */
+__STATIC_INLINE uint32_t LL_SPI_DMA_GetTxRegAddr(SPI_TypeDef *SPIx)
+{
+  return (uint32_t) &(SPIx->TXDR);
+}
+
+/**
+  * @brief  Get the data register address used for DMA transfer
+  * @rmtoll RXDR           RXDR            LL_SPI_DMA_GetRxRegAddr
+  * @param  SPIx SPI Instance
+  * @retval Address of data register
+  */
+__STATIC_INLINE uint32_t LL_SPI_DMA_GetRxRegAddr(SPI_TypeDef *SPIx)
+{
+  return (uint32_t) &(SPIx->RXDR);
+}
+
+/**
   * @}
   */
 


### PR DESCRIPTION
This patch adds the LL functions to get the address of SPI Tx/Rx reg.
Dislike other series, the stm32H7 has two registers for Tx and Rx
but no LL function is available to get their location when DMA requires
it for its peripheral address reg.

Signed-off-by: Francois Ramu <francois.ramu@st.com>

## IMPORTANT INFORMATION

### Contributor License Agreement (CLA)
* The Pull Request feature will be considered by STMicroelectronics after the signature of a **Contributor License Agreement (CLA)** by the submitter.
* If you did not sign such agreement, please follow the steps mentioned in the CONTRIBUTING.md file.
