### PR TITLE
Fix compiler warnings under -Wswitch-enum

### DIFF
--- a/Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_dma.c
+++ b/Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_dma.c
@@ -1611,6 +1611,9 @@ HAL_StatusTypeDef HAL_DMA_RegisterCallback(DMA_HandleTypeDef *hdma, HAL_DMA_Call
       hdma->XferAbortCallback = pCallback;
       break;
 
+    /* Registering the same callback for everything is unlikely to be helpful
+       or desired, thus we treat it as error */
+    case  HAL_DMA_XFER_ALL_CB_ID:
     default:
       status =  HAL_ERROR;
       break;

--- a/Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_uart.c
+++ b/Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_uart.c
@@ -3121,6 +3121,9 @@ HAL_StatusTypeDef UART_SetConfig(UART_HandleTypeDef *huart)
       case UART_CLOCKSOURCE_LSE:
         pclk = (uint32_t) LSE_VALUE;
         break;
+      case UART_CLOCKSOURCE_D2PCLK1:   /* Not available for Low-Power-UART */
+      case UART_CLOCKSOURCE_D2PCLK2:   /* Not available for Low-Power-UART */
+      case UART_CLOCKSOURCE_UNDEFINED:
       default:
         pclk = 0U;
         ret = HAL_ERROR;
@@ -3191,6 +3194,8 @@ HAL_StatusTypeDef UART_SetConfig(UART_HandleTypeDef *huart)
       case UART_CLOCKSOURCE_LSE:
         pclk = (uint32_t) LSE_VALUE;
         break;
+      case UART_CLOCKSOURCE_D3PCLK1:   /* Only available for Low-Power-UART */
+      case UART_CLOCKSOURCE_UNDEFINED:
       default:
         pclk = 0U;
         ret = HAL_ERROR;
@@ -3247,6 +3252,8 @@ HAL_StatusTypeDef UART_SetConfig(UART_HandleTypeDef *huart)
       case UART_CLOCKSOURCE_LSE:
         pclk = (uint32_t) LSE_VALUE;
         break;
+      case UART_CLOCKSOURCE_D3PCLK1:   /* Only available for Low-Power-UART */
+      case UART_CLOCKSOURCE_UNDEFINED:
       default:
         pclk = 0U;
         ret = HAL_ERROR;


### PR DESCRIPTION
By being explicit about cases that are treated as "default"
in switch statements.

This does not change behavior at all, it only silences compiler
warnings that may be very helpful in spotting programmer mistakes
elsewhere.

Also added some comments about why those cases are handled as
default/error.

(I did sign the CLA already)
