### PR TITLE
Fix 'errno' redefinition issue for GCC >= 10

### DIFF
--- a/Middlewares/Third_Party/LwIP/system/OS/sys_arch.c
+++ b/Middlewares/Third_Party/LwIP/system/OS/sys_arch.c
@@ -41,9 +41,6 @@
 
 #include "cmsis_os.h"
 
-#if defined(LWIP_PROVIDE_ERRNO)
-int errno;
-#endif
 
 /*-----------------------------------------------------------------------------------*/
 //  Creates an empty mailbox.


### PR DESCRIPTION
Since GCC version 10 the global uninitialized variables go into .bss instead of .common, i.e. the -fno-common has became the default. This way linking stage ends up with 'errno' redefinition error because both nano-libc and libc already provide it.
The Middlewares/Third_Party/LwIP/src/include/lwip/errno.h already provide the mechanism to either use the library based symbol or custom one by 'errno' macro definition.
