### PR TITLE
correction of HAL driver version

### DIFF
--- a/Drivers/STM32H7xx_HAL_Driver/README.md
+++ b/Drivers/STM32H7xx_HAL_Driver/README.md
@@ -39,7 +39,7 @@ Tag v1.8.0    | Tag v1.8.0      | Tag v5.4.0 | Tag v1.7.0 (and following, if any
 Tag v1.9.0    | Tag v1.9.0      | Tag v5.4.0 | Tag v1.8.0 (and following, if any, till next HAL tag)
 Tag v1.10.0   | Tag v1.10.0     | Tag v5.6.0 | Tag v1.9.0 (and following, if any, till next HAL tag)
 Tag v1.10.1   | Tag v1.10.1     | Tag v5.6.0 | Tag v1.9.1 (and following, if any, till next HAL tag)
-Tag v1.10.2   | Tag v1.10.2     | Tag v5.6.0 | Tag v1.10.0 (and following, if any, till next HAL tag)
+Tag v1.11.0   | Tag v1.10.2     | Tag v5.6.0 | Tag v1.10.0 (and following, if any, till next HAL tag)
 
 The full **STM32CubeH7** MCU package is available [here](https://github.com/STMicroelectronics/STM32CubeH7).
 


### PR DESCRIPTION
HAL driver version is v1.11.0 in STM32CubeH7

## IMPORTANT INFORMATION

### Contributor License Agreement (CLA)
* The Pull Request feature will be considered by STMicroelectronics after the signature of a **Contributor License Agreement (CLA)** by the submitter.
* If you did not sign such agreement, please follow the steps mentioned in the CONTRIBUTING.md file.
