### PR TITLE
Issue #231: improvements on ethernet regarding stability and deadlocks

### DIFF
--- a/Drivers/BSP/Components/lan8742/lan8742.c
+++ b/Drivers/BSP/Components/lan8742/lan8742.c
@@ -316,12 +316,6 @@ int32_t LAN8742_GetLinkState(lan8742_Object_t *pObj)
     return LAN8742_STATUS_READ_ERROR;
   }
   
-  /* Read Status register again */
-  if(pObj->IO.ReadReg(pObj->DevAddr, LAN8742_BSR, &readval) < 0)
-  {
-    return LAN8742_STATUS_READ_ERROR;
-  }
-  
   if((readval & LAN8742_BSR_LINK_STATUS) == 0)
   {
     /* Return Link Down status */

--- a/Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_eth.c
+++ b/Drivers/STM32H7xx_HAL_Driver/Src/stm32h7xx_hal_eth.c
@@ -1890,13 +1890,18 @@ void HAL_ETH_IRQHandler(ETH_HandleTypeDef *heth)
       }
       else
       {
+      	const uint32_t emask =  ETH_DMACSR_CDE
+      			              | ETH_DMACSR_ETI
+  							  | ETH_DMACSR_ERI
+  							  | ETH_DMACSR_RWT
+  							  | ETH_DMACSR_RBU
+  							  | ETH_DMACSR_AIS
+  							  | ETH_DMACSR_TBU;
         /* Get DMA error status  */
-        heth->DMAErrorCode = READ_BIT(heth->Instance->DMACSR, (ETH_DMACSR_CDE | ETH_DMACSR_ETI | ETH_DMACSR_RWT |
-                                                               ETH_DMACSR_RBU | ETH_DMACSR_AIS));
+        heth->DMAErrorCode = READ_BIT(heth->Instance->DMACSR, emask);
 
         /* Clear the interrupt summary flag */
-        __HAL_ETH_DMA_CLEAR_IT(heth, (ETH_DMACSR_CDE | ETH_DMACSR_ETI | ETH_DMACSR_RWT |
-                                      ETH_DMACSR_RBU | ETH_DMACSR_AIS));
+        __HAL_ETH_DMA_CLEAR_IT(heth, heth->DMAErrorCode);
       }
 #if (USE_HAL_ETH_REGISTER_CALLBACKS == 1)
       /* Call registered Error callback*/


### PR DESCRIPTION
Here is our effort that improves on issues mentioned in 
https://github.com/STMicroelectronics/STM32CubeH7/issues/231

Additional it fixes some  related, but minor issues.

Known issue:
During tx we can not always recover from all errors and blocking tx can halt forever. For this reasons, users of sequential-style api (netcon/socket) should enable [`LWIP_SO_SNDTIMEO`](https://www.nongnu.org/lwip/2_1_x/group__lwip__opts__socket.html#ga1162cb685f202d9b21c11344b8209a58) and use timeout for example [`netconn_set_sendtimeout`](https://www.nongnu.org/lwip/2_1_x/api_8h.html#a3ce3ad9f660e99b11fec20cafaf8f016) as a prevention against stall.

Kind regards, Luka
