### PR TITLE
Fix DMA overflow in ADCDualModeInterleaved example

### DIFF
--- a/Projects/NUCLEO-H743ZI/Examples/ADC/ADC_DualModeInterleaved/Src/main.c
+++ b/Projects/NUCLEO-H743ZI/Examples/ADC/ADC_DualModeInterleaved/Src/main.c
@@ -200,7 +200,7 @@ int main(void)
   /* Start ADCx and ADCy multimode conversion on regular group with transfer by DMA */
   if (HAL_ADCEx_MultiModeStart_DMA(&AdcHandle_master,
                                    (uint32_t *)aADCDualConvertedValues,
-                                    ADCCONVERTEDVALUES_BUFFER_SIZE
+                                    ADCCONVERTEDVALUES_BUFFER_SIZE/2 /* size in words */
                                   ) != HAL_OK)
   {
     /* Start Error */


### PR DESCRIPTION
With `DMA_MDATAALIGN_WORD` the `HAL_ADCEx_MultiModeStart_DMA` call expects the length parameter to be in words, not half words.

Without this change, the DMA interrupt overwrites the `aADCxConvertedValues` buffer located immediately behind the, DMA buffer, which isn't a problem for this example since it's immediately overwritten with the correct values in the `HAL_ADC_ConvCpltCallback`.

However, for those using this reference example this bug is likely to cause memory corruption in their application.

I have signed the CLA.
