### PR TITLE
Fix comment typo in NUCLEO-H743ZI/Examples/PWR/PWR_Domain3SystemControl

### DIFF
--- a/Projects/NUCLEO-H743ZI/Examples/PWR/PWR_Domain3SystemControl/Src/main.c
+++ b/Projects/NUCLEO-H743ZI/Examples/PWR/PWR_Domain3SystemControl/Src/main.c
@@ -292,7 +292,7 @@ int main(void)
     /* -20- Set LED1 Off and enter Stop mode */
     BSP_LED_Off(LED1);
 
-    /* Enter the system in STOP mdoe */
+    /* Enter the system in STOP mode */
     HAL_PWR_EnterSTOPMode(PWR_MAINREGULATOR_ON, PWR_STOPENTRY_WFI);
 
     /* -21- Check the results after wake-up */


### PR DESCRIPTION
Hello,

Fixes a typo in a comment in the PWR_Domain3SystemControl example.

No functional code changes.