### PR TITLE
Fix comment typo in NUCLEO-H743ZI/Examples/PWR/PWR_Domain3SystemControl

### DIFF
--- a/Projects/NUCLEO-H743ZI/Examples/PWR/PWR_Domain3SystemControl/Src/main.c
+++ b/Projects/NUCLEO-H743ZI/Examples/PWR/PWR_Domain3SystemControl/Src/main.c
@@ -292,7 +292,7 @@ int main(void)
     /* -20- Set LED1 Off and enter Stop mode */
     BSP_LED_Off(LED1);
 
-    /* Enter the system in STOP mdoe */
+    /* Enter the system in STOP mode */
     HAL_PWR_EnterSTOPMode(PWR_MAINREGULATOR_ON, PWR_STOPENTRY_WFI);
 
     /* -21- Check the results after wake-up */

--- a/Projects/STM32H745I-DISCO/Examples/PWR/PWR_Domain3SystemControl/CM7/Src/main.c
+++ b/Projects/STM32H745I-DISCO/Examples/PWR/PWR_Domain3SystemControl/CM7/Src/main.c
@@ -308,7 +308,7 @@ int main(void)
     /* -20- Set LED1 Off and enter Stop mode */
     BSP_LED_Off(LED1);
 
-    /* Enter the system in STOP mdoe */
+    /* Enter the system in STOP mode */
     HAL_PWR_EnterSTOPMode(PWR_MAINREGULATOR_ON, PWR_STOPENTRY_WFI);
 
     /* -21- Check the results after wake-up */

--- a/Projects/STM32H745I-DISCO/Examples/PWR/PWR_Hold_Mechanism/readme.txt
+++ b/Projects/STM32H745I-DISCO/Examples/PWR/PWR_Hold_Mechanism/readme.txt
@@ -76,7 +76,7 @@ Two LEDs are used in this program:
   - LED2: To indicate the CM4 status. LED2 is ON when CM4 is in RUN mode  
           and LED2 is OFF when CM4 enters STOP mode.
 
-After RESET LED1 is turned ON during 5 seconds to indicate that CM7 core is in RUN mdoe
+After RESET LED1 is turned ON during 5 seconds to indicate that CM7 core is in RUN mode
 and LED2 is turned ON during 3 seconds to indicate that CM4 core is in RUN mode.
 Then the system will automatically enters STOP mode when:
   - D1 Domain enters DSTOP mode after calling the HAL_PWREx_EnterSTOPMode function 

--- a/Projects/STM32H745I-DISCO/Examples/PWR/PWR_STANDBY/readme.txt
+++ b/Projects/STM32H745I-DISCO/Examples/PWR/PWR_STANDBY/readme.txt
@@ -60,7 +60,7 @@ Two LEDs are used in this program:
   - LED2: To indicate the CM4 status. LED2 is ON when CM4 is in RUN mode  
           and LED2 is OFF when CM4 enters STANDBY mode.
           
-After RESET LED1 is turned ON during 5 seconds to indicate that CM7 core is in RUN mdoe
+After RESET LED1 is turned ON during 5 seconds to indicate that CM7 core is in RUN mode
 and LED2 is turned ON during 3 seconds to indicate that CM4 core is in RUN mode.
 Then the system will automatically enters STANDBY mode when:
   - D1 Domain enters DSTANDBY mode after calling the HAL_PWREx_EnterSTANDBYMode function 

--- a/Projects/STM32H745I-DISCO/Examples/PWR/PWR_STANDBY_RTC/readme.txt
+++ b/Projects/STM32H745I-DISCO/Examples/PWR/PWR_STANDBY_RTC/readme.txt
@@ -63,7 +63,7 @@ Two LEDs are used in this program:
 
 When the system enters STANDBY mode then current consumption can be measured.
 
-After RESET LED1 is turned ON during 5 seconds to indicate that CM7 core is in RUN mdoe
+After RESET LED1 is turned ON during 5 seconds to indicate that CM7 core is in RUN mode
 and LED2 is turned ON during 3 seconds to indicate that CM4 core is in RUN mode.
 Then the system will automatically enters STANDBY mode when:
   - D1 Domain enters DSTANDBY mode after calling the HAL_PWREx_EnterSTANDBYMode function 

--- a/Projects/STM32H745I-DISCO/Examples/PWR/PWR_STOP_RTC/readme.txt
+++ b/Projects/STM32H745I-DISCO/Examples/PWR/PWR_STOP_RTC/readme.txt
@@ -96,7 +96,7 @@ Two LEDs are used in this program:
           LED2 is OFF when CM4 enters STOP mode. 
 
 After RESET LED1 is turned ON during 5 seconds to indicate that CM7 core is in RUN 
-mdoe and LED2 is turned ON during 3 seconds to indicate that CM4 core is in RUN mode.
+mode and LED2 is turned ON during 3 seconds to indicate that CM4 core is in RUN mode.
 Then the system will automatically enters STOP mode when:
   - D1 Domain enters DSTOP mode after calling the HAL_PWREx_EnterSTOPMode function 
     by CM7 core => LED1 turns OFF.

--- a/Projects/STM32H747I-EVAL/Examples/PWR/PWR_Hold_Mechanism/readme.txt
+++ b/Projects/STM32H747I-EVAL/Examples/PWR/PWR_Hold_Mechanism/readme.txt
@@ -77,7 +77,7 @@ Three LEDs are used in this program:
           and LED2 is OFF when CM4 enters STOP mode. 
   - LED3: To indicate if a configuration error occurred during program execution.
 
-After RESET LED1 is turned ON during 5 seconds to indicate that CM7 core is in RUN mdoe
+After RESET LED1 is turned ON during 5 seconds to indicate that CM7 core is in RUN mode
 and LED2 is turned ON during 3 seconds to indicate that CM4 core is in RUN mode.
 Then the system will automatically enters STOP mode when:
   - D1 Domain enters DSTOP mode after calling the HAL_PWREx_EnterSTOPMode function 

--- a/Projects/STM32H747I-EVAL/Examples/PWR/PWR_STANDBY/readme.txt
+++ b/Projects/STM32H747I-EVAL/Examples/PWR/PWR_STANDBY/readme.txt
@@ -60,7 +60,7 @@ Three LEDs are used in this program:
           and LED2 is OFF when CM4 enters STANDBY mode. 
   - LED3: To indicate if a configuration error occurred during program execution.
 
-After RESET LED1 is turned ON during 5 seconds to indicate that CM7 core is in RUN mdoe
+After RESET LED1 is turned ON during 5 seconds to indicate that CM7 core is in RUN mode
 and LED2 is turned ON during 3 seconds to indicate that CM4 core is in RUN mode.
 Then the system will automatically enters STANDBY mode when:
   - D1 Domain enters DSTANDBY mode after calling the HAL_PWREx_EnterSTANDBYMode function 

--- a/Projects/STM32H747I-EVAL/Examples/PWR/PWR_STANDBY_RTC/readme.txt
+++ b/Projects/STM32H747I-EVAL/Examples/PWR/PWR_STANDBY_RTC/readme.txt
@@ -63,7 +63,7 @@ Three LEDs are used in this program:
 
 When the system enters STANDBY mode then current consumption can be measured.
 
-After RESET LED1 is turned ON during 5 seconds to indicate that CM7 core is in RUN mdoe
+After RESET LED1 is turned ON during 5 seconds to indicate that CM7 core is in RUN mode
 and LED2 is turned ON during 3 seconds to indicate that CM4 core is in RUN mode.
 Then the system will automatically enters STANDBY mode when:
   - D1 Domain enters DSTANDBY mode after calling the HAL_PWREx_EnterSTANDBYMode function 

--- a/Projects/STM32H747I-EVAL/Examples/PWR/PWR_STOP_RTC/readme.txt
+++ b/Projects/STM32H747I-EVAL/Examples/PWR/PWR_STOP_RTC/readme.txt
@@ -95,7 +95,7 @@ Three LEDs are used in this program:
   - LED3: To indicate if a configuration error occurred during program execution.
 
 After RESET LED1 is turned ON during 5 seconds to indicate that CM7 core is in RUN 
-mdoe and LED2 is turned ON during 3 seconds to indicate that CM4 core is in RUN mode.
+mode and LED2 is turned ON during 3 seconds to indicate that CM4 core is in RUN mode.
 Then the system will automatically enters STOP mode when:
   - D1 Domain enters DSTOP mode after calling the HAL_PWREx_EnterSTOPMode function 
     by CM7 core => LED1 turns OFF.


### PR DESCRIPTION
Hello,

Reopening this contribution after signing the CLA.

This change only fixes a typo in a source comment in the
PWR_Domain3SystemControl example.

No functional code changes.